### PR TITLE
Allow changelog-bot to work with forked repos

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -1,8 +1,6 @@
 name: Changelog Bot
 
-on:
-  pull_request:
-    types: [closed]
+on: push
 
 jobs:
   changelog-bot:
@@ -11,6 +9,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Update Changelog if applicable
-        uses: ponylang/changelog-bot-action@0.0.1
+        uses: ponylang/changelog-bot-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Update CHANGELOG.md
     steps:
-      - uses: actions/checkout@v1
       - name: Update Changelog if applicable
         uses: ponylang/changelog-bot-action@master
         env:

--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update CHANGELOG.md
     steps:
-      - name: Update Changelog if applicable
+      - name: Update Changelog
         uses: ponylang/changelog-bot-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY --from=changelog-tool /usr/local/bin/changelog-tool /usr/local/bin/changelo
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN apk add --update jq \
+RUN apk add --update bash \
+  jq \
   git \
   perl \
   grep \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add --update jq \
   git \
   perl \
   grep \
-  curl
+  curl \
+  openssh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY entrypoint.sh /entrypoint.sh
 RUN apk add --update jq \
   git \
   perl \
-  grep
+  grep \
+  curl
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apk add --update jq \
   git \
   perl \
   grep \
-  curl \
-  openssh
+  curl
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Update CHANGELOG.md
     steps:
-      - uses: actions/checkout@v1
       - name: Update Changelog if applicable
         uses: ponylang/changelog-bot-action@master
         env:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ See the Pony [changelog-tool](https://github.com/ponylang/changelog-tool) for ad
 ```yml
 name: Changelog Bot
 
-on:
-  pull_request:
-    types: [closed]
+on: push
 
 jobs:
   changelog-bot:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Update CHANGELOG.md
     steps:
-      - name: Update Changelog if applicable
+      - name: Update Changelog
         uses: ponylang/changelog-bot-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,7 +56,7 @@ echo -e "\e[34mCreating temporary work directory in /tmp"
 WORK_DIR=`mktemp -d -p /tmp` && cd "${WORK_DIR}"
 # clone repository
 echo -e "\e[34mCloning ${BASE_BRANCH} of ${REPO} into ${WORK_DIR}"
-git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git" .
+git clone --depth=1 --branch="${BASE_BRANCH}" "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${REPO}"
 
 # make sure we are up to date
 echo -e "\e[34mPulling latest changes"
@@ -73,14 +73,6 @@ echo -e "\e[34mCommiting CHANGELOG.md changes (if any)"
 git add CHANGELOG.md
 git commit -m "$COMMIT_MESSAGE"
 
-echo -e "\e[34mPushing changes (if any)"
-# Now we want to be quiet - don't want to print the GITHUB_TOKEN var.
-set +x
-
-if [[ -z "${GITHUB_TOKEN}" ]]; then
-  echo "GITHUB_TOKEN environment variable is missing - add it as a secret!"
-  exit 1
-fi
-
 # push those changes son
+echo -e "\e[34mPushing changes (if any)"
 git push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set -e
+
 # Get commit SHA from PushEvent
 SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
 REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo -e "\e[31mGITHUB_TOKEN needs to be set in env. Exiting."
+  exit 1
+fi
+
 # Get commit SHA from PushEvent
 SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
 REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,7 @@ SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
 REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")
 
 # Search for merged PR featuring our SHA in our REPO
-echo -e "\e[34mRunning changelog bot for ${SHA} in ${REPO}"
+echo -e "\e[34mRunning changelog-bot for ${SHA} in ${REPO}"
 PR_URL=$(curl -s "https://api.github.com/search/issues?q=is:merged+sha:${SHA}+repo:${REPO}" | jq -r '.items[].pull_request.url')
 
 if [[ -z ${PR_URL} ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,8 @@ if [[ -z "${GITHUB_TOKEN}" ]]; then
 fi
 
 # Get commit SHA from PushEvent
-SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
-REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")
+SHA=$(jq -r '.head_commit.id' "${GITHUB_EVENT_PATH}")
+REPO=$(jq -r '.repository.full_name' "${GITHUB_EVENT_PATH}")
 
 # Search for merged PR featuring our SHA in our REPO
 echo -e "\e[34mRunning changelog-bot for ${SHA} in ${REPO}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,9 +49,12 @@ chmod 600 $HOME/.netrc
 git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 
+# create work directory
+echo -e "\e[34mCreating temporary work directory in /tmp"
+WORK_DIR=`mktemp -d -p /tmp` && cd "${WORK_DIR}"
 # clone repository
-git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git" ./cloned_repo
-cd cloned_repo
+echo -e "\e[34mClong ${BASE_BRANCH} of ${REPO} into ${WORK_DIR}"
+git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git" .
 
 # make sure we are up to date
 echo -e "\e[34mPulling latest changes"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,9 +49,10 @@ chmod 600 $HOME/.netrc
 git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 
+# clone repository
+git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git"
+
 # make sure we are up to date
-echo -e "\e[34mCheckout ${BASE_BRANCH}"
-git checkout "${BASE_BRANCH}"
 echo -e "\e[34mPulling latest changes"
 git pull
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")
 echo -e "\e[34mRunning changelog bot for ${SHA} in ${REPO}"
 PR_URL=$(curl -s "https://api.github.com/search/issues?q=is:merged+sha:${SHA}+repo:${REPO}" | jq -r '.items[].pull_request.url')
 
-if [[ -z PR_URL ]]; then
+if [[ -z ${PR_URL} ]]; then
   echo -e "\e[33mNo PR associated with ${SHA}. Exiting."
   exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh -l
 
-cat "${GITHUB_EVENT_PATH}"
 # Get commit SHA from PushEvent
 SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
 REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 cat "${GITHUB_EVENT_PATH}"
 # Get commit SHA from PushEvent
-SHA=$(jq '.payload.head' "${GITHUB_EVENT_PATH}")
-REPO=$(jq '.repo.name' "${GITHUB_EVENT_PATH}")
+SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
+REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")
 
 # Search for merged PR featuring our SHA in our REPO
 echo "Running changelog bot for ${SHA} in ${REPO}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -l
 
+cat "${GITHUB_EVENT_PATH}"
 # Get commit SHA from PushEvent
 SHA=$(jq '.payload.head' "${GITHUB_EVENT_PATH}")
 REPO=$(jq '.repo.name' "${GITHUB_EVENT_PATH}")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ echo -e "\e[34mRunning changelog-bot for ${SHA} in ${REPO}"
 PR_URL=$(curl -s "https://api.github.com/search/issues?q=is:merged+sha:${SHA}+repo:${REPO}" | jq -r '.items[].pull_request.url')
 
 if [[ -z ${PR_URL} ]]; then
-  echo -e "\e[33mNo PR associated with ${SHA}. Exiting."
+  echo -e "\e[33mNo merged PR associated with ${SHA}. Exiting."
   exit 0
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,8 @@ git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 
 # clone repository
-git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git"
+git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git" ./cloned_repo
+cd cloned_repo
 
 # make sure we are up to date
 echo -e "\e[34mPulling latest changes"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,7 +53,7 @@ git config --global user.email 'ponylang.main@gmail.com'
 echo -e "\e[34mCreating temporary work directory in /tmp"
 WORK_DIR=`mktemp -d -p /tmp` && cd "${WORK_DIR}"
 # clone repository
-echo -e "\e[34mClong ${BASE_BRANCH} of ${REPO} into ${WORK_DIR}"
+echo -e "\e[34mCloning ${BASE_BRANCH} of ${REPO} into ${WORK_DIR}"
 git clone --depth=1 --branch="${BASE_BRANCH}" "git@github.com:${REPO}.git" .
 
 # make sure we are up to date

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ BASE_BRANCH=$(jq -r '.base.ref' pr.json)
 PULL_REQUEST_TITLE=$(jq -r '.title' pr.json)
 PULL_REQUEST_NUMBER=$(jq -r '.number' pr.json)
 COMMIT_MESSAGE="Update CHANGELOG for PR #${PULL_REQUEST_NUMBER} [skip ci]"
-CHANGELOG_ENTRY="- ${PULL_REQUEST_TITLE} ([PR #${PULL_REQUEST_NUMBER}](${PULL_REQUEST_URL}))"
+CHANGELOG_ENTRY="- ${PULL_REQUEST_TITLE} ([PR #${PULL_REQUEST_NUMBER}](${PR_URL}))"
 
 CHANGELOG_TYPES=$(
   cat pr.json |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ SHA=$(jq '.head_commit.id' "${GITHUB_EVENT_PATH}")
 REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")
 
 # Search for merged PR featuring our SHA in our REPO
-echo "Running changelog bot for ${SHA} in ${REPO}"
+echo -e "\e[34mRunning changelog bot for ${SHA} in ${REPO}"
 PR_URL=$(curl -s "https://api.github.com/search/issues?q=is:merged+sha:${SHA}+repo:${REPO}" | jq -r '.items[].pull_request.url')
 
 if [[ -z PR_URL ]]; then
@@ -15,9 +15,11 @@ if [[ -z PR_URL ]]; then
 fi
 
 # We have a PR url, let's fetch it.
+echo -e "\e[34mFetching ${PR_URL}"
 curl -s "${PR_URL}" >> pr.json
 
 # Extract information from pull request
+echo -e "\e[34mExtracting information from PR"
 BASE_BRANCH=$(jq -r '.base.ref' pr.json)
 PULL_REQUEST_TITLE=$(jq -r '.title' pr.json)
 PULL_REQUEST_NUMBER=$(jq -r '.number' pr.json)
@@ -33,6 +35,7 @@ CHANGELOG_TYPES=$(
 )
 # git setup
 # Set up .netrc file with GitHub credentials
+echo -e "\e[34mSetting up GitHub credentials"
 cat <<- EOF > $HOME/.netrc
       machine github.com
       login $GITHUB_ACTOR
@@ -48,18 +51,23 @@ git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 
 # make sure we are up to date
+echo -e "\e[34mCheckout ${BASE_BRANCH}"
 git checkout "${BASE_BRANCH}"
+echo -e "\e[34mPulling latest changes"
 git pull
 
+echo -e "\e[34mUpdating CHANGELOG.md"
 for CHANGELOG_TYPE in $CHANGELOG_TYPES; do
   CHANGELOG_HEADER="### ${CHANGELOG_TYPE}"
   perl -i -ne "BEGIN{$/ = undef;} s@(${CHANGELOG_HEADER}\s*)@\1${CHANGELOG_ENTRY}\n@; print" CHANGELOG.md
 done
 
 # Add CHANGELOG changes and commit
+echo -e "\e[34mCommiting CHANGELOG.md changes (if any)"
 git add CHANGELOG.md
 git commit -m "$COMMIT_MESSAGE"
 
+echo -e "\e[34mPushing changes (if any)"
 # Now we want to be quiet - don't want to print the GITHUB_TOKEN var.
 set +x
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,50 +1,63 @@
 #!/bin/sh -l
 
-# Set up .netrc file with GitHub credentials
-git_setup ( ) {
-  cat <<- EOF > $HOME/.netrc
-        machine github.com
-        login $GITHUB_ACTOR
-        password $GITHUB_TOKEN
-        machine api.github.com
-        login $GITHUB_ACTOR
-        password $GITHUB_TOKEN
-EOF
+# Get commit SHA from PushEvent
+SHA=$(jq '.payload.head' "${GITHUB_EVENT_PATH}")
+REPO=$(jq '.repo.name' "${GITHUB_EVENT_PATH}")
 
-  chmod 600 $HOME/.netrc
+# Search for merged PR featuring our SHA in our REPO
+echo "Running changelog bot for ${SHA} in ${REPO}"
+PR_URL=$(curl -s "https://api.github.com/search/issues?q=is:merged+sha:${SHA}+repo:${REPO}" | jq -r '.items[].pull_request.url')
 
-  git config --global user.name 'Ponylang Main Bot'
-  git config --global user.email 'ponylang.main@gmail.com'
-}
-
-PULL_REQUEST_MERGED=$(jq '.pull_request.merged' "${GITHUB_EVENT_PATH}")
-if [[ "true" != "$PULL_REQUEST_MERGED" ]]; then
-  echo "Ignoring not-merged pull request"
+if [[ -z PR_URL ]]; then
+  echo -e "\e[33mNo PR associated with ${SHA}. Exiting."
   exit 0
 fi
 
-git_setup
+# We have a PR url, let's fetch it.
+curl -s "${PR_URL}" >> pr.json
 
-BASE_BRANCH=$(jq -r '.pull_request.base.ref' "${GITHUB_EVENT_PATH}")
-PULL_REQUEST_TITLE=$(jq -r '.pull_request.title' "${GITHUB_EVENT_PATH}")
-PULL_REQUEST_NUMBER=$(jq -r '.number' "${GITHUB_EVENT_PATH}")
+# Extract information from pull request
+BASE_BRANCH=$(jq -r '.base.ref' pr.json)
+PULL_REQUEST_TITLE=$(jq -r '.title' pr.json)
+PULL_REQUEST_NUMBER=$(jq -r '.number' pr.json)
 COMMIT_MESSAGE="Update CHANGELOG for PR #${PULL_REQUEST_NUMBER} [skip ci]"
 CHANGELOG_ENTRY="- ${PULL_REQUEST_TITLE} ([PR #${PULL_REQUEST_NUMBER}](${PULL_REQUEST_URL}))"
 
 CHANGELOG_TYPES=$(
-  cat "${GITHUB_EVENT_PATH}" |
-  jq -r '.pull_request.labels | map(.name) | join("'"$IFS"'")' |
+  cat pr.json |
+  jq -r '.labels | map(.name) | join("'"$IFS"'")' |
   grep 'changelog - ' |
   grep -o -E 'added|changed|fixed' |
   awk '{$1=toupper(substr($1,0,1))substr($1,2)}1' # capitalize the first letter
 )
+# git setup
+# Set up .netrc file with GitHub credentials
+cat <<- EOF > $HOME/.netrc
+      machine github.com
+      login $GITHUB_ACTOR
+      password $GITHUB_TOKEN
+      machine api.github.com
+      login $GITHUB_ACTOR
+      password $GITHUB_TOKEN
+EOF
+
+chmod 600 $HOME/.netrc
+
+git config --global user.name 'Ponylang Main Bot'
+git config --global user.email 'ponylang.main@gmail.com'
+
+# make sure we are up to date
+git checkout "${BASE_BRANCH}"
+git pull
 
 for CHANGELOG_TYPE in $CHANGELOG_TYPES; do
   CHANGELOG_HEADER="### ${CHANGELOG_TYPE}"
   perl -i -ne "BEGIN{$/ = undef;} s@(${CHANGELOG_HEADER}\s*)@\1${CHANGELOG_ENTRY}\n@; print" CHANGELOG.md
 done
 
-git add -A && git commit -m "$COMMIT_MESSAGE" --allow-empty
+# Add CHANGELOG changes and commit
+git add CHANGELOG.md
+git commit -m "$COMMIT_MESSAGE"
 
 # Now we want to be quiet - don't want to print the GITHUB_TOKEN var.
 set +x
@@ -54,4 +67,5 @@ if [[ -z "${GITHUB_TOKEN}" ]]; then
   exit 1
 fi
 
-git push --set-upstream origin HEAD:${BASE_BRANCH}
+# push those changes son
+git push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ pushd "${WORK_DIR}" || exit 1
 
 # clone repository
 echo -e "\e[34mCloning ${BASE_BRANCH} of ${REPO} into ${WORK_DIR}"
-git clone --depth=1 --branch="${BASE_BRANCH}" "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${REPO}"
+git clone --depth=1 --branch="${BASE_BRANCH}" "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${REPO}" .
 
 # make sure we are up to date
 echo -e "\e[34mPulling latest changes"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,11 +64,19 @@ for CHANGELOG_TYPE in $CHANGELOG_TYPES; do
   perl -i -ne "BEGIN{$/ = undef;} s@(${CHANGELOG_HEADER}\s*)@\1${CHANGELOG_ENTRY}\n@; print" CHANGELOG.md
 done
 
+# Checking to see if we need to commit
+DIRTY=$(git status -s)
+
+if [[ ${DIRTY} == "" ]]; then
+  echo -e "\e[33mNo changes to CHANGELOG.md. Exiting."
+  exit 0
+fi
+
 # Add CHANGELOG changes and commit
-echo -e "\e[34mCommiting CHANGELOG.md changes (if any)"
+echo -e "\e[34mCommiting CHANGELOG.md changes"
 git add CHANGELOG.md
 git commit -m "$COMMIT_MESSAGE"
 
 # push those changes son
-echo -e "\e[34mPushing changes (if any)"
+echo -e "\e[34mPushing changes"
 git push

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,9 @@ echo -e "\e[34mExtracting information from PR"
 BASE_BRANCH=$(jq -r '.base.ref' pr.json)
 PULL_REQUEST_TITLE=$(jq -r '.title' pr.json)
 PULL_REQUEST_NUMBER=$(jq -r '.number' pr.json)
+PR_HTML_URL=$(jq -r '.html_url' pr.json)
 COMMIT_MESSAGE="Update CHANGELOG for PR #${PULL_REQUEST_NUMBER} [skip ci]"
-CHANGELOG_ENTRY="- ${PULL_REQUEST_TITLE} ([PR #${PULL_REQUEST_NUMBER}](${PR_URL}))"
+CHANGELOG_ENTRY="- ${PULL_REQUEST_TITLE} ([PR #${PULL_REQUEST_NUMBER}](${PR_HTML_URL}))"
 
 CHANGELOG_TYPES=$(
   cat pr.json |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -l
+#!/bin/bash
 
 set -e
 
@@ -15,7 +15,7 @@ REPO=$(jq '.repository.full_name' "${GITHUB_EVENT_PATH}")
 echo -e "\e[34mRunning changelog-bot for ${SHA} in ${REPO}"
 PR_URL=$(curl -s "https://api.github.com/search/issues?q=is:merged+sha:${SHA}+repo:${REPO}" | jq -r '.items[].pull_request.url')
 
-if [[ -z ${PR_URL} ]]; then
+if [[ -z "${PR_URL}" ]]; then
   echo -e "\e[33mNo merged PR associated with ${SHA}. Exiting."
   exit 0
 fi
@@ -40,25 +40,15 @@ CHANGELOG_TYPES=$(
   awk '{$1=toupper(substr($1,0,1))substr($1,2)}1' # capitalize the first letter
 )
 # git setup
-# Set up .netrc file with GitHub credentials
-echo -e "\e[34mSetting up GitHub credentials"
-cat <<- EOF > $HOME/.netrc
-      machine github.com
-      login $GITHUB_ACTOR
-      password $GITHUB_TOKEN
-      machine api.github.com
-      login $GITHUB_ACTOR
-      password $GITHUB_TOKEN
-EOF
-
-chmod 600 $HOME/.netrc
-
+echo -e "\e[34mSetting up git configuration"
 git config --global user.name 'Ponylang Main Bot'
 git config --global user.email 'ponylang.main@gmail.com'
 
 # create work directory
 echo -e "\e[34mCreating temporary work directory in /tmp"
-WORK_DIR=`mktemp -d -p /tmp` && cd "${WORK_DIR}"
+WORK_DIR=$(mktemp -d -p /tmp)
+pushd "${WORK_DIR}" || exit 1
+
 # clone repository
 echo -e "\e[34mCloning ${BASE_BRANCH} of ${REPO} into ${WORK_DIR}"
 git clone --depth=1 --branch="${BASE_BRANCH}" "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${REPO}"


### PR DESCRIPTION
Prior to this commit, the changelog-bot-action was triggered by `pull_request` events. `pull_request events` run in the forked repo's scope. not the base repo. Therefore, updates like what the changelog-bot does can't be executed as they don't have access to push.

This commit switches us to being triggered by `push` events. It's a bit more complicated to get the logic working and a few more API calls, but it all works.

Closes #5 
Closes #6