### PR TITLE
Only run the changelog-bot against master

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -1,6 +1,9 @@
 name: Changelog Bot
 
-on: push
+on: 
+  push:
+    branches:
+      - master
 
 jobs:
   changelog-bot:


### PR DESCRIPTION
Given our workflow, we never use it for anything other than PRs
that merge into master. Given that, running on pushes to other
branches is wasteful.

This commit turns off for anything that isn't master.