### PR TITLE
Correctly work when there are no labels

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,7 +37,8 @@ CHANGELOG_TYPES=$(
   cat pr.json |
   jq -r '.labels | map(.name) | join("'"$IFS"'")' |
   grep 'changelog - ' |
-  grep -o -E 'added|changed|fixed'
+  grep -o -E 'added|changed|fixed' ||
+  true
 )
 # git setup
 echo -e "\e[34mSetting up git configuration"


### PR DESCRIPTION
This fix comes from @jemc.

This script is using `set -e` so that errors won't go unnoticed.
But when commands are piped together, only the exit status of the
final command matters.

The `grep` command obviously fails when none of the tags are present
to find, which is causing the script to crash in that case. But it
seems that `awk` was always returning a success exit status even when
the `grep` failed, so that explains why we didn't see that issue when
the `awk` was the final command.

The `true` command returns success unconditionally and prints nothing.
So, adding ` || true` has the desired effect of explicitly
ignoring/consuming the error from `grep`, while printing nothing into
the output stream of the subshell, so that the `CHANGELOG_TYPES`
variable will be an empty string in that case like we want.

Closes #9