### PR TITLE
Update README to not run on every push

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ name: Changelog Bot
 
 on:
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
     paths-ignore:
       - CHANGELOG.md
 


### PR DESCRIPTION
Prior to this change to the README, if you pushed only a tag, the
bot would run. This was caused by the lack of a branch listing.

GitHub action filters for push are a little weird.

This change will now cause us to run on any branch for any commit
that isn't just a tag change but also has a file modified that isn't
CHANGELOG.md.