### PR TITLE
Lint entrypoint.py

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,14 @@ name: PR
 on: pull_request
 
 jobs:
+  lint-entrypoint-py:
+    name: Lint entrypoint.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: pylint
+        run: make pylint
+
   superlinter:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
@@ -24,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build --pull ."
+        run: make build
 
   verify-changelog:
     name: Verify CHANGELOG is valid

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apk add --update --no-cache \
   git \
   py3-pip
 
-RUN pip3 install gitpython PyGithub
+RUN pip3 install \
+  gitpython \
+  PyGithub \
+  pylint
 
 ENTRYPOINT ["/entrypoint.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+TAG := docker.pkg.github.com/ponylang/changelog-bot-action/changelog-bot:latest
+
+all: build
+
+build:
+	docker build --pull -t ${TAG} .
+
+pylint: build
+	docker run --entrypoint pylint --rm ${TAG} /entrypoint.py
+
+.PHONY: build pylint

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,18 +1,27 @@
 #!/usr/bin/python3
+# pylint: disable=C0103
+# pylint: disable=C0114
 
-import git,json,os,re,subprocess,sys
+import json
+import os
+import re
+import subprocess
+import sys
+import git
 from github import Github
 
-changelog_labels = ['changelog - added', 'changelog - changed', 'changelog - fixed']
+CHANGELOG_LABELS = ['changelog - added',
+                    'changelog - changed',
+                    'changelog - fixed']
 
-ENDC   = '\033[0m'
-ERROR  = '\033[31m'
-INFO   = '\033[34m'
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
 NOTICE = '\033[33m'
 
-if not 'GITHUB_TOKEN' in os.environ:
-  print(ERROR + "GITHUB_TOKEN needs to be set in env. Exiting." + ENDC)
-  sys.exit(1)
+if 'GITHUB_TOKEN' not in os.environ:
+    print(ERROR + "GITHUB_TOKEN needs to be set in env. Exiting." + ENDC)
+    sys.exit(1)
 
 # login
 github = Github(os.environ['GITHUB_TOKEN'])
@@ -31,8 +40,8 @@ print(INFO + "Query: " + query + ENDC)
 results = github.search_issues(query='is:merged', sha=sha, repo=repo_name)
 
 if results.totalCount == 0:
-  print(NOTICE + "No merged PR associated with " + sha + ". Exiting.")
-  sys.exit(0)
+    print(NOTICE + "No merged PR associated with " + sha + ". Exiting.")
+    sys.exit(0)
 
 pr_id = results[0].number
 print(INFO + "PR found " + str(pr_id) + ENDC)
@@ -43,17 +52,23 @@ pull_request = repo.get_pull(pr_id)
 # check to make sure that the PR had at least one changelog label
 pr_changelog_labels = []
 for l in pull_request.labels:
-  print(INFO + "PR had label: " + l.name + ENDC)
-  if l.name in changelog_labels:
-    pr_changelog_labels.append(l.name)
+    print(INFO + "PR had label: " + l.name + ENDC)
+    if l.name in CHANGELOG_LABELS:
+        pr_changelog_labels.append(l.name)
 
 if not pr_changelog_labels:
-  print(NOTICE + "No changelog labels associated with PR #" + str(pr_id) \
-    + ". Exiting." + ENDC)
-  sys.exit(0)
+    print(NOTICE
+          + "No changelog labels associated with PR #"
+          + str(pr_id)
+          + ". Exiting."
+          + ENDC)
+    sys.exit(0)
 
 print(INFO + "Cloning repo." + ENDC)
-clone_from = "https://" + os.environ['GITHUB_ACTOR'] + ":" + os.environ['GITHUB_TOKEN'] + "@github.com/" + repo_name
+clone_from = "https://" + os.environ['GITHUB_ACTOR'] \
+              + ":" + os.environ['GITHUB_TOKEN'] \
+              + "@github.com/" \
+              + repo_name
 pr_base_branch = pull_request.base.ref
 clone_options = ["--branch=" + pr_base_branch]
 git = git.Repo.clone_from(clone_from, '.', multi_options=clone_options).git
@@ -65,13 +80,20 @@ git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
 # construct changelog_entry
 pull_request_title = pull_request.title
 pr_html_url = pull_request.html_url
-changelog_entry = pull_request_title + " ([PR #" + str(pr_id) + "](" \
-  + pr_html_url + "))"
+changelog_entry = pull_request_title \
+                  + " ([PR #" + str(pr_id) \
+                  + "](" \
+                  + pr_html_url \
+                  + "))"
 
 print(INFO + "Updating CHANGELOG.md." + ENDC)
 for prcl in pr_changelog_labels:
-  change_type = re.sub('changelog - ', '', prcl)
-  subprocess.call(['changelog-tool', 'add', change_type, changelog_entry, '-e'])
+    change_type = re.sub('changelog - ', '', prcl)
+    subprocess.call(['changelog-tool',
+                     'add',
+                     change_type,
+                     changelog_entry,
+                     '-e'])
 
 print(INFO + "Adding git changes." + ENDC)
 git.add('CHANGELOG.md')
@@ -79,15 +101,17 @@ git.commit('-m', "Update CHANGELOG for PR #" + str(pr_id))
 
 print(INFO + "Pushing changes." + ENDC)
 push_failures = 0
-while(True):
-  try:
-    git.push()
-    break
-  except:
-    push_failures += 1
-    if (push_failures <= 5):
-      print(NOTICE + "Failed to push. Going to pull and try again." + ENDC)
-      git.pull()
-    else:
-      print(ERROR + "Failed to push again. Giving up." + ENDC)
-      raise
+while True:
+    try:
+        git.push()
+        break
+    except git.GitCommandError:
+        push_failures += 1
+        if push_failures <= 5:
+            print(NOTICE
+                  + "Failed to push. Going to pull and try again."
+                  + ENDC)
+            git.pull()
+        else:
+            print(ERROR + "Failed to push again. Giving up." + ENDC)
+            raise


### PR DESCRIPTION
Sets up linting of entrypoint.sh. I previously tried to do using
GitHub's superlinter, however, being able to use Python linters
with the required dependencies is a bit of a nightmare.

This update includes pylink in the same docker container that our
action normally runs in making it easy to build for both running
and for linting of the code.

Also included is a Makefile that currently allows for building
the container as well as linting it via two targets:

- build
- pylint

The Makefile is a first step towards being able to build fixed containers
on release and use those rather than rebuilding each time the action is
used for actions in various workflows. I'm planning on hosting those
released versions in GitHub packages, thus the stub "tag" in the Makefile
referencing the GitHub packages url. The name in the tag is currently unimportant
and can be ignored until such time as a push action is added to Makefile at
which point the tag name will become "real".

This commit also includes changes to entrypoint.py needed to get it to pass
the pylint linting.