### PR TITLE
Improve logging around multiple push attempts

### DIFF
--- a/.release-notes/35.md
+++ b/.release-notes/35.md
@@ -1,0 +1,5 @@
+## Improve logging around multiple push attempts
+
+Previously, if the bot failed to push its updates, it would create a log message for each pull that it attempted but only for the first push. This could be confusing to the user.
+
+Now each push and pull attempt will be logged.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -101,10 +101,10 @@ print(INFO + "Adding git changes." + ENDC)
 git.add('CHANGELOG.md')
 git.commit('-m', "Update CHANGELOG for PR #" + str(pr_id))
 
-print(INFO + "Pushing changes." + ENDC)
 push_failures = 0
 while True:
     try:
+        print(INFO + "Pushing changes." + ENDC)
         git.push()
         break
     except GitCommandError:


### PR DESCRIPTION
If a failure was encountered, we wouldn't get push logging for
each push only the first.