### PR TITLE
Update to work with newer versions of git

### DIFF
--- a/.release-notes/cranky-git.md
+++ b/.release-notes/cranky-git.md
@@ -1,0 +1,5 @@
+## Update to work with newer versions of git
+
+Newer versions of git have added a check to see if the user running a command is the same as the user who owns the repository. If they don't match, the command fails. Adding the repository directory to a "safe list" addresses the issue.
+
+We've updated accordingly.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -78,6 +78,7 @@ print(INFO + "Setting up git configuration." + ENDC)
 git.config('--global', 'user.name', os.environ['INPUT_GIT_USER_NAME'])
 git.config('--global', 'user.email', os.environ['INPUT_GIT_USER_EMAIL'])
 git.config('--global', 'branch.autosetuprebase', 'always')
+git.config('--global', '--add', 'safe.directory', os.environ['GITHUB_WORKSPACE'])
 
 # construct changelog_entry
 pull_request_title = pull_request.title


### PR DESCRIPTION
Newer versions of git have added a check to see if the user running a command
is the same as the user who owns the repository. If they don't match, the
command fails. Adding the repository directory to a "safe list" addresses the
issue.