### PR TITLE
Add sleep and retry when secondary rate limit impacts on PR search

### DIFF
--- a/.release-notes/r.md
+++ b/.release-notes/r.md
@@ -1,0 +1,9 @@
+## Handle GitHub secondary rate limit failure
+
+The changelog-bot-action makes extensive use of the GitHub API. As such, it can trigger rate limits that cause a failure. We've found that it is rather easy when using the bot across a number of repositories to hit a "secondary rate limit failure". Basically that is "you are doing too many API calls at once".
+
+The error is transient. If someone was to notice, they could restart the failed changelog-bot run and it would work. However, that requires someone to notice.
+
+With this release, we've added a retry for the one time we know that the limit can be triggered. If the rate limit is triggered, the bot will wait for 30 seconds before trying again. If it encounters 5 failures, it will give up and quit.
+
+It is possible that we'll need to add similar returns around other GitHub API calls. If we do, additional updates will be made.


### PR DESCRIPTION
We hit this error semi-regularly. GitHub's secondary rate limiting is easy to trigger. It often will happen if multiple requests to the API are made at the same time from different jobs resulting in a failure. The failure is easy to fix by rerunning the job, but a user has to notice.

There might be other places that we can hit a similar issue, but this commit addresses the known location.

Fixes #44