### PR TITLE
Start pushing Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,18 @@ jobs:
       - pre-artefact-creation
     steps:
       - uses: actions/checkout@v3
-      - name: Docker login
+      - name: Login to DockerHub
         run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
         env:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      - name: Login to GitHub Container Registry
+        # v2.2.0
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: make push
 

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,16 @@ all: build
 build:
 	docker build --pull -t "${IMAGE}:${IMAGE_TAG}" .
 	docker build --pull -t "${IMAGE}:latest" .
+	docker build --pull -t "ghcr.io/${IMAGE}:${IMAGE_TAG}" .
+	docker build --pull -t "ghcr.io/${IMAGE}:latest" .
 
 push: build
 	docker push "${IMAGE}:${IMAGE_TAG}"
 	docker push "${IMAGE}:latest"
+	docker push "ghcr.io/${IMAGE}:${IMAGE_TAG}"
+	docker push "ghcr.io/${IMAGE}:latest"
 
 pylint: build
-	docker run --entrypoint pylint --rm "${IMAGE}:latest" /entrypoint.py
+	docker run --entrypoint pylint --rm "ghcr.io/${IMAGE}:latest" /entrypoint.py
 
 .PHONY: build pylint


### PR DESCRIPTION
We are transitioning from DockerHub to GitHub Container Registry. This commit adds pushing Docker images to GHCR in addition to DockerHub. Eventually, we will drop pushing to DockerHub and leave only pushing to GHCR.