### PR TITLE
Don't push new images to DockerHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,6 @@ jobs:
       - pre-artefact-creation
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,10 @@ endif
 all: build
 
 build:
-	docker build --pull -t "${IMAGE}:${IMAGE_TAG}" .
-	docker build --pull -t "${IMAGE}:latest" .
 	docker build --pull -t "ghcr.io/${IMAGE}:${IMAGE_TAG}" .
 	docker build --pull -t "ghcr.io/${IMAGE}:latest" .
 
 push: build
-	docker push "${IMAGE}:${IMAGE_TAG}"
-	docker push "${IMAGE}:latest"
 	docker push "ghcr.io/${IMAGE}:${IMAGE_TAG}"
 	docker push "ghcr.io/${IMAGE}:latest"
 


### PR DESCRIPTION
We've transitioned to GitHub Container Registry.