### PR TITLE
Handle Additional GitHub secondary rate limit failure

### DIFF
--- a/.release-notes/68.md
+++ b/.release-notes/68.md
@@ -1,0 +1,3 @@
+## Handle Additional GitHub secondary rate limit failure
+
+In our previous version, we added support for retrying when a secondary rate limit failure occurred. However, since that time, we have seen secondary rate limit failures that are not handled by the previous fix. This update adds a retry for the one time we know that the limit can be triggered. If the rate limit is triggered, the bot will wait for 30 seconds before trying again. If it encounters 5 failures, it will give up and quit.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -12,6 +12,7 @@ import git
 from git.exc import GitCommandError
 from github import Github
 from github.GithubException import RateLimitExceededException
+from github.GithubException import GithubException
 
 CHANGELOG_LABELS = ['changelog - added',
                     'changelog - changed',
@@ -66,6 +67,20 @@ while True:
             time.sleep(30)
         else:
             print(ERROR + "Search failed again. Giving up." + ENDC)
+            raise
+    except GithubException as e:
+        if "You have exceeded a secondary rate limit" in e.data['message']:
+            search_failures += 1
+            if search_failures <= 5:
+                print(NOTICE
+                    + "Search failed due to secondary rate limit exceeded. "
+                    + "Sleeping and trying again."
+                    + ENDC)
+                time.sleep(30)
+            else:
+                print(ERROR + "Search failed again. Giving up." + ENDC)
+                raise
+        else:
             raise
 
 repo = github.get_repo(repo_name)


### PR DESCRIPTION
We previously handled secondary rate limit errors, however, it turns out that we aren't getting the exception type that we were seeing then for all secondary rate limits.

This PR updates to handle the generic "GitHubException" that PyGitHub uses. If we get the more generic error and it contains a secondary rate limit message from GitHub, we will handle with our usual "wait and try again" strategy.