### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint entrypoint.py
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: pylint
         run: make pylint
 
@@ -22,7 +22,7 @@ jobs:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -37,7 +37,7 @@ jobs:
     name: Validate Docker image builds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Docker build
         run: make build
 
@@ -45,7 +45,7 @@ jobs:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Verify CHANGELOG
         uses: docker://ghcr.io/ponylang/changelog-tool:release
         with:

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
@@ -52,7 +52,7 @@ jobs:
     needs:
       - build-and-push-image
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.