### PR TITLE
Upgrade docker/login-action to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
-        # v2.2.0
-        uses: docker/login-action@5139682d94efc37792e6b54386b5b470a68a4737
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The docker/login-action v3 line uses Node.js 20 which is deprecated by GitHub Actions. This upgrades to v4 which uses Node.js 24.