### PR TITLE
Retry when GitHub API doesn't immediately return PR for a commit

### DIFF
--- a/.release-notes/retry-pr-lookup.md
+++ b/.release-notes/retry-pr-lookup.md
@@ -1,0 +1,3 @@
+## Retry when GitHub API doesn't immediately return PR for a commit
+
+The GitHub Search API sometimes doesn't return PR results immediately after a merge event. Previously, the bot would see no results and exit, skipping the CHANGELOG update entirely. Now it retries up to 5 times with a 10-second delay, giving the API time to catch up.

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -45,6 +45,7 @@ query = "q=is:merged+sha:" + sha + "+repo:" + repo_name
 print(INFO + "Query: " + query + ENDC)
 pr_id = 0
 search_failures = 0
+not_found_retries = 0
 while True:
     try:
         results = github.search_issues(query='is:merged', sha=sha,
@@ -59,8 +60,19 @@ while True:
             print(INFO + "PR found " + str(pr_id) + ENDC)
             break
         except IndexError:
-            print(NOTICE + "No merged PR associated with " + sha + ". Exiting." + ENDC)
-            sys.exit(0)
+            not_found_retries += 1
+            if not_found_retries <= 5:
+                print(NOTICE
+                      + "No merged PR associated with " + sha + " yet. "
+                      + "Sleeping and trying again."
+                      + ENDC)
+                time.sleep(10)
+            else:
+                print(NOTICE
+                      + "No merged PR associated with " + sha
+                      + ". Exiting."
+                      + ENDC)
+                sys.exit(0)
     except RateLimitExceededException:
         search_failures += 1
         if search_failures <= 5:


### PR DESCRIPTION
The GitHub Search API has started exhibiting eventual consistency behavior where PR results aren't available immediately after a merge event. Previously we'd see no results and exit, silently skipping the CHANGELOG update. Now we retry up to 5 times with a 10-second delay before giving up.