### PR TITLE
Fix intermittent crash when looking up the PR for a commit

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,4 @@
+## Fix intermittent crash when looking up the PR for a commit
+
+The bot could fail with an internal error while searching for the pull request associated with a commit when the GitHub API returned an unexpected response. The lookup now handles those response cases gracefully and the bot retries instead of crashing.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix intermittent crash when looking up the PR for a commit ([PR #83](https://github.com/ponylang/changelog-bot-action/pull/83))
 
 ### Added
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --update --no-cache \
 
 RUN pip3 install --break-system-packages \
   gitpython \
-  PyGithub==v1.54.1 \
+  PyGithub==v1.59.1 \
   pylint
 
 ENTRYPOINT ["/entrypoint.py"]


### PR DESCRIPTION
The bot crashed intermittently with an `AttributeError: 'NoneType' object has no attribute 'get'` while looking up the PR associated with a commit. The root cause is in the underlying HTTP client's handling of an unexpected GitHub API response shape; the version included in this image has the defensive fix and the bot's existing retry loop now takes effect instead of crashing.

CHANGELOG and release notes are included manually because changelog-bot-action and release-notes-bot-action are currently hitting the same crash, so the automation that would normally add them on merge can't be relied on.